### PR TITLE
Paging3 를 사용하여 Pagination 구현

### DIFF
--- a/data/src/main/java/com/example/data/repository/NaverRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/NaverRepositoryImpl.kt
@@ -1,17 +1,32 @@
 package com.example.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.example.data.repository.datasource.RemoteDataSource
+import com.example.data.repository.datasourceimpl.MovieInfoListPagingSource
 import com.example.domain.model.MovieInfoModel
 import com.example.domain.repository.NaverRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class NaverRepositoryImpl @Inject constructor(
     private val remoteDataSource: RemoteDataSource
 ) : NaverRepository {
     override fun requestMovieList(query: StateFlow<String>): Flow<PagingData<MovieInfoModel>> {
-        TODO("Pagination 구현")
+        return Pager(
+            config = PagingConfig(pageSize = 10),
+            pagingSourceFactory = {
+                MovieInfoListPagingSource(
+                    remoteDataSource = remoteDataSource,
+                    searchQuery = query,
+                    limit = 10
+                )
+            }
+        ).flow.distinctUntilChanged().flowOn(Dispatchers.IO)
     }
 }

--- a/data/src/main/java/com/example/data/repository/datasourceimpl/MovieInfoListPagingSource.kt
+++ b/data/src/main/java/com/example/data/repository/datasourceimpl/MovieInfoListPagingSource.kt
@@ -1,0 +1,62 @@
+package com.example.data.repository.datasourceimpl
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.example.data.mapper.ObjectMapper.toMovieInfoModelList
+import com.example.data.repository.datasource.RemoteDataSource
+import com.example.domain.model.MovieInfoModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import javax.inject.Inject
+
+class MovieInfoListPagingSource @Inject constructor(
+    private val remoteDataSource: RemoteDataSource,
+    private val searchQuery: StateFlow<String>,
+    private val limit: Int
+) : PagingSource<Int, MovieInfoModel>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, MovieInfoModel> {
+        val pageNumber = params.key ?: 1
+
+        try {
+            val response = withContext(Dispatchers.IO) {
+                remoteDataSource.requestSearchMovie(
+                    query = searchQuery.value, start = pageNumber, display = limit
+                )
+            }
+
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    val movieList = it.items.toMovieInfoModelList()
+
+                    /**
+                     * nextKey : naver Api 의 start 는 index 이고, 현재 display(limit)가 10 이므로
+                     * 10 이후에 start 값은 11이 되어야함
+                     * 스크롤되어 페이지가 추가될때 마다 10개씩 가져온다.
+                     */
+                    return LoadResult.Page(
+                        data = movieList,
+                        prevKey = null,
+                        nextKey = if (it.items.size >= limit) {
+                            pageNumber + limit
+                        } else {
+                            null
+                        }
+                    )
+                }
+            }
+
+            return LoadResult.Error(Exception("영화 정보를 가져오는데 실패하였습니다."))
+        } catch (e: Exception) {
+            Timber.e("paging Catch Error => ${e.message}")
+            return LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, MovieInfoModel>): Int? {
+        // 새로고침 될 때 항상 전부 새로고침 되도록 null 을 return
+        return null
+    }
+}


### PR DESCRIPTION
## 🍎 Paging3 를 사용하여 Naver Open API Response Pagination 으로 구현
- `MovieInfoListPagingSource` : 새로고침, 데이터 Load 시 어떤 식으로 데이터를 가져올지 정의
  > **_참고_** 👇
  >> - nextKey : naver api 의 query param `start` 는 시작 index 이고, 현재 `display(limit)` 가 10 이므로, 10 이후에 `start` 값은 11이 되어야함
  >> - 스크롤되어 페이지가 추가될떄 마다 10개씩 데이터를 가져옴
- `NaverRespositoryImpl` : PagingData 로 View에 넘겨주는 방식으로 구현