### PR TITLE
🍀 서버에 이미지 업로드 대응 코드 추가

### DIFF
--- a/app/src/main/java/com/example/moviesearchapp/view/utils/Utils.kt
+++ b/app/src/main/java/com/example/moviesearchapp/view/utils/Utils.kt
@@ -1,7 +1,14 @@
 package com.example.moviesearchapp.view.utils
 
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
+import android.provider.MediaStore
+import android.provider.OpenableColumns
 import android.text.Html
+import android.webkit.MimeTypeMap
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -10,8 +17,12 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.example.domain.model.FileInfoModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.*
 
 fun String.htmlToString(): String {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -56,4 +67,86 @@ inline fun <reified T> Flow<T>.observeOnLifecycle(
             }
         }
     }
+}
+
+// bitmap -> ByteArray 로 압축 > UpLoadFile 의 두 번째 인자에 들어감
+fun compressImageWithJpeg(bitmap: Bitmap): ByteArray {
+    val stream = ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+    return stream.toByteArray()
+}
+
+// UpLoadFile 의 첫 번째 인자에 들어감
+fun getFileInfo(context: Context, contentUri: Uri): FileInfoModel {
+    // We tried querying the ContentResolver...didn't work out
+    // Try extracting the last path segment
+    var fileName: String = contentUri.lastPathSegment!!
+    var fileSize = -1L
+    var mimeType = "*/*"
+
+    when (contentUri.scheme) {
+        ContentResolver.SCHEME_FILE -> {
+            val file = File(contentUri.path!!)
+
+            fileName = file.name
+            fileSize = file.length()
+
+            val fileExtension: String = file.extension
+
+            MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                fileExtension.lowercase(Locale.ENGLISH)
+            )?.let {
+                mimeType = it
+            }
+        }
+
+        ContentResolver.SCHEME_CONTENT -> {
+            @Suppress("DEPRECATION")
+            val projection = arrayOf(
+                MediaStore.Images.Media.DATA,
+                OpenableColumns.DISPLAY_NAME,
+                OpenableColumns.SIZE
+            )
+
+            context.contentResolver.getType(contentUri)?.let { mimeType = it }
+
+            context.contentResolver.query(contentUri, projection, null, null, null).use { cursor ->
+                if (cursor != null && cursor.moveToFirst()) {
+                    // Try extracting content size
+                    val sizeIndex: Int = cursor.getColumnIndex(OpenableColumns.SIZE)
+                    if (sizeIndex != -1) {
+                        fileSize = cursor.getLong(sizeIndex)
+                    }
+
+                    // Try extracting display name
+                    var name: String? = null
+
+                    // Strategy: The column name is NOT guaranteed to be indexed by DISPLAY_NAME
+                    // so, we try two methods
+                    var nameIndex: Int = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex != -1) {
+                        name = cursor.getString(nameIndex)
+                    }
+
+                    if (nameIndex == -1 || name == null) {
+                        @Suppress("DEPRECATION")
+                        nameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+                        if (nameIndex != -1) {
+                            name = cursor.getString(nameIndex)
+                        }
+                    }
+
+                    if (name != null) {
+                        fileName = name
+                    }
+                }
+            }
+        }
+
+        else -> {
+            throw RuntimeException("Only scheme content:// or file:// is accepted")
+        }
+    }
+
+    return FileInfoModel(fileName, fileSize, mimeType)
 }

--- a/data/src/main/java/com/example/data/utils/ApiClient.kt
+++ b/data/src/main/java/com/example/data/utils/ApiClient.kt
@@ -1,0 +1,41 @@
+package com.example.data.utils
+
+import com.example.domain.model.UploadFile
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/**
+ * @Multipart 안에 RequestBody 로 다른 Query 가 들어가는 경우 사용
+ * ex_) 👇
+ * @Multipart
+ * @POST("${API_NAME}/qna/write")
+ * suspend fun bbsQNAWrite(
+ *     @Part("subject") subject: RequestBody,
+ *     @Part("contents") contents: RequestBody,
+ *     @Part("category") category: RequestBody,
+ *     @Part multiPart: MultipartBody.Part?,
+ * ): Response<BaseResponse>
+ */
+fun setValue(value: String): RequestBody = value
+    .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaType())
+
+fun setValue(value: Long): RequestBody = value.toString()
+    .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaType())
+
+fun setValue(value: Int): RequestBody = value.toString()
+    .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaType())
+
+// ex_) requestBodyToMultiPart("profile2", profile.file.name, byteArrayToRequestBody(profile))
+fun requestBodyToMultiPart(
+    title: String,
+    fileName: String,
+    body: RequestBody
+): MultipartBody.Part {
+    return MultipartBody.Part.createFormData(title, fileName, body)
+}
+
+fun byteArrayToRequestBody(profile: UploadFile): RequestBody {
+    return profile.byte.toRequestBody(profile.file.mimType.toMediaType(), 0, profile.byte.size)
+}

--- a/domain/src/main/java/com/example/domain/model/FileInfoModel.kt
+++ b/domain/src/main/java/com/example/domain/model/FileInfoModel.kt
@@ -1,0 +1,11 @@
+package com.example.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class FileInfoModel(
+    var name: String,
+    val size: Long = -1L,
+    val mimType: String
+): Parcelable

--- a/domain/src/main/java/com/example/domain/model/UploadFile.kt
+++ b/domain/src/main/java/com/example/domain/model/UploadFile.kt
@@ -1,0 +1,25 @@
+package com.example.domain.model
+
+// Repository 에서 requestBodyToMultiPart 를 사용하여 UploadFile 👉 @MultiPart.Part 로 바꿔줌
+data class UploadFile(
+    val file: FileInfoModel,
+    val byte: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UploadFile
+
+        if (file != other.file) return false
+        if (!byte.contentEquals(other.byte)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = file.hashCode()
+        result = 31 * result + byte.contentHashCode()
+        return result
+    }
+}


### PR DESCRIPTION
# 🍀 서버에 이미지 업로드 대응 코드 추가

## ☘️ Domain Layer
### 🌱 보다 간편한 Image Upload 를 위해 필요한 `data class` 생성 (`Domain Layer` 에 작성)
- `FileInfoModel` 👉 파일에 대한 정보를 가지고 있는 `data class`
- `UploadFile` 👉 파일 정보와, image 압축 ByteArray 를 가지고 있는 `data class`
  >  Repository 에서 requestBodyToMultiPart 를 사용하여 UploadFile 👉 @MultiPart.Part 로 바꿔줌
- > **_예제_** 👇
  > 
  ``` kotlin
  @Parcelize
  data class FileInfoModel(
      var name: String,
      val size: Long = -1L,
      val mimType: String
  ): Parcelable

  data class UploadFile(
      val file: FileInfoModel,
      val byte: ByteArray
  )
  ```
---

## ☘️ Data Layer
### 🌱 1. Retrofit 을 사용한 이미지 업로더 (`Data Layer 에 작성`)
- `@MultiPart` Annotation 사용
- `body` 의 경우 👇
  > - `RequestBody` 👉 기타(String, Int, Long) 등을 Body 에 넣을 경우 사용
  > - `MultipartBody.Part` 👉 이미지를 Body 에 넣을 경우 사용
- > **_예제_** 👇
  >
  ``` kotlin
  @Multipart
  @POST("${API_NAME}/qna/write")
  suspend fun bbsQNAWrite(
      @Part("subject") subject: RequestBody,
      @Part("contents") contents: RequestBody,
      @Part("category") category: RequestBody,
      @Part multiPart: MultipartBody.Part?,
  ): Response<BaseResponse>
  ```

### 🌱 2. ApiClient 생성
- String, Long, Int 를 `RequestBody` 로 바꿔주는 함수 생성
- > **_예제_** 👇
  >
  ``` kotlin
  fun setValue(value: String): RequestBody = value
      .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaType())

  fun setValue(value: Long): RequestBody = value.toString()
      .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaType())

  fun setValue(value: Int): RequestBody = value.toString()
      .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaType())
  ```
- 이미지를 `MultipartBody.Part` 로 바꿔주는 함수 생성
- > **_예제_** 👇
  >
  ``` kotlin
  fun requestBodyToMultiPart(
      title: String,
      fileName: String,
      body: RequestBody
  ): MultipartBody.Part {
      return MultipartBody.Part.createFormData(title, fileName, body)
  }
  
  fun byteArrayToRequestBody(profile: UploadFile): RequestBody {
      return profile.byte.toRequestBody(profile.file.mimType.toMediaType(), 0, profile.byte.size)
  }
  ```
- > **_예제 1 사용_** 👇
  > 
  ``` kotlin
  requestBodyToMultiPart("profile2", profile.file.name, byteArrayToRequestBody(profile))
  ```
---
## ☘️ Presentation Layer
### 🌱 이미지를 UploadFile 로 바꿔줄 때 도움을 주는 함수 추가
- `getFileInfo` : Uri 👉 FileInfoModel 로 바꿔주는 함수 
  > `UpLoadFile` 의 `첫 번째` 인자에 들어감

  > **_예제_** 👇
  > 
  ``` kotlin
  fun getFileInfo(context: Context, contentUri: Uri): FileInfoModel {
      // We tried querying the ContentResolver...didn't work out
      // Try extracting the last path segment
      var fileName: String = contentUri.lastPathSegment!!
      var fileSize = -1L
      var mimeType = "*/*"

      when (contentUri.scheme) {
          ContentResolver.SCHEME_FILE -> {
              val file = File(contentUri.path!!)

              fileName = file.name
              fileSize = file.length()

              val fileExtension: String = file.extension

              MimeTypeMap.getSingleton().getMimeTypeFromExtension(
                  fileExtension.lowercase(Locale.ENGLISH)
              )?.let {
                  mimeType = it
              }
          }

          ContentResolver.SCHEME_CONTENT -> {
              @Suppress("DEPRECATION")
              val projection = arrayOf(
                  MediaStore.Images.Media.DATA,
                  OpenableColumns.DISPLAY_NAME,
                  OpenableColumns.SIZE
              )

              context.contentResolver.getType(contentUri)?.let { mimeType = it }

              context.contentResolver.query(contentUri, projection, null, null, null).use { cursor ->
                  if (cursor != null && cursor.moveToFirst()) {
                      // Try extracting content size
                      val sizeIndex: Int = cursor.getColumnIndex(OpenableColumns.SIZE)
                      if (sizeIndex != -1) {
                          fileSize = cursor.getLong(sizeIndex)
                      }

                      // Try extracting display name
                      var name: String? = null

                      // Strategy: The column name is NOT guaranteed to be indexed by DISPLAY_NAME
                      // so, we try two methods
                      var nameIndex: Int = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
                      if (nameIndex != -1) {
                          name = cursor.getString(nameIndex)
                      }

                      if (nameIndex == -1 || name == null) {
                          @Suppress("DEPRECATION")
                          nameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
                          if (nameIndex != -1) {
                              name = cursor.getString(nameIndex)
                          }
                      }

                      if (name != null) {
                          fileName = name
                      }
                  }
              }
          }

          else -> {
              throw RuntimeException("Only scheme content:// or file:// is accepted")
          }
      }

      return FileInfoModel(fileName, fileSize, mimeType)
  }
  ```
- `compressImageWithJpeg` : bitmap 👉 ByteArray 로 압축하는 함수
  > `UpLoadFile` 의 `두 번째` 인자에 들어감

  > **_예제_** 👇
  >
  ``` kotlin
  fun compressImageWithJpeg(bitmap: Bitmap): ByteArray {
      val stream = ByteArrayOutputStream()
      bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
      return stream.toByteArray()
  }
  ```